### PR TITLE
Public data

### DIFF
--- a/app/exports/query_sets/measurements/measurement_or_fact_query.py
+++ b/app/exports/query_sets/measurements/measurement_or_fact_query.py
@@ -28,25 +28,31 @@ def measurement_or_fact_query(measurement_choices, is_admin_or_contributor):
     now_format_1 = now.strftime('%Y-%m-%d %H:%M:%S +02:00')
     now_format_2 = now.strftime('%d %m %Y')
 
-    if is_admin_or_contributor:
-        references = Replace(
-                Replace(
-                    'source_entity__reference__master_reference__citation',
-                    Value('<i>'),
-                    Value('')
-                ),
-                Value('</i>'),
-                Value('')
+    mb_reference = Concat(
+        Value('The MammalBase community '),
+        Value(now_format_1),
+        Value(' , Data version '),
+        Value(now_format_2),
+        Value(' at https://mammalbase.net/me/'),
+        output_field=CharField()
+    )
+
+    references = Replace(
+        Replace(
+            'source_entity__reference__master_reference__citation',
+            Value('<i>'),
+            Value('')
+        ),
+        Value('</i>'),
+        Value('')
+    )
+
+    if not is_admin_or_contributor:
+        references = Case(
+            When(source_entity__reference__master_reference__is_public = True,
+                then = references ),
+                default = mammalbase_reference
         )
-    else:
-        references = Concat(
-                    Value('The MammalBase community '),
-                    Value(now_format_1),
-                    Value(' , Data version '),
-                    Value(now_format_2),
-                    Value(' at https://mammalbase.net/me/'),
-                    output_field=CharField()
-                )
 
     query = base.exclude(non_active).annotate(
         measurement_id=Concat(

--- a/app/exports/query_sets/measurements/measurement_or_fact_query.py
+++ b/app/exports/query_sets/measurements/measurement_or_fact_query.py
@@ -51,7 +51,7 @@ def measurement_or_fact_query(measurement_choices, is_admin_or_contributor):
         references = Case(
             When(source_entity__reference__master_reference__is_public = True,
                 then = references ),
-                default = mammalbase_reference
+                default = mb_reference
         )
 
     query = base.exclude(non_active).annotate(

--- a/app/mb/models/models.py
+++ b/app/mb/models/models.py
@@ -416,6 +416,7 @@ class MasterReference(BaseModel):
     page = models.CharField(max_length=50, help_text="Enter the Page(s) of the Standard Reference", blank=True, null=True,)
     citation = models.CharField(max_length=500, help_text="Enter the Citation of the Standard Reference")
 #    link = models.URLField(max_length=200, help_text="Enter a valid URL for the Source Reference", blank=True, null=True,)
+    is_public = models.BooleanField(help_text="Enter if the source is public", blank=False, null=True,)
 
     class Meta:
         ordering = ['citation']


### PR DESCRIPTION
Add a new field to model MasterRefererence, is_public. If the citation is marked as public, when exported without data_admin or data_contributor rights it will still show the original reference instead of the MammalBase one.