### PR TITLE
Fix broken master_location_detail template

### DIFF
--- a/app/mb/templates/mb/master_location_detail.html
+++ b/app/mb/templates/mb/master_location_detail.html
@@ -109,6 +109,7 @@
             <th class="w3-quarter w3-text-teal">Status:</th>
             <td class="w3-threequarter">{{ relation.data_status.name }}</td>
           </tr>
+          {% endif %}
         {% endfor %}
         </table>
     {% else %}


### PR DESCRIPTION
## Summary
- ensure `master_location_detail.html` has matching `{% if %}`/`{% endif %}` blocks

## Testing
- `python app/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685bde0289bc8329b171326bcc23559e