### PR TITLE
Fix matching existing MasterLocation

### DIFF
--- a/app/matchtools/location_api.py
+++ b/app/matchtools/location_api.py
@@ -22,7 +22,7 @@ class LocationAPI:
         response = requests.get(url)
         data = response.json()
         if 'geonames' in data:
-            nature_reservations = [place for place in data['geonames'] if place.get('fcode') == 'RESN' or place.get('fcode') == 'RESW' or place.get('fcode') == 'RESF']
+            nature_reservations = [place for place in data['geonames'] if place.get('fcode') == 'RESN' or place.get('fcode') == 'RESW' or place.get('fcode') == 'RESF' or place.get('fcode') == 'PRK']
             return nature_reservations
         else:
             return []

--- a/app/matchtools/location_match.py
+++ b/app/matchtools/location_match.py
@@ -105,3 +105,23 @@ def add_locations(geo_names_location, source_location_id):
         match_locations(hierarchy_location, source_location)
 
     return added_locations
+
+
+def get_hierarchy_chain(master_location):
+    """Return list of hierarchy names from continent to the given master location."""
+
+    chain = []
+    current = master_location
+    while current is not None:
+        chain.append(current)
+        current = current.higher_geography
+
+    chain.reverse()
+
+    start_index = 0
+    for i, loc in enumerate(chain):
+        if loc.continent:
+            start_index = i
+            break
+
+    return [loc.name for loc in chain[start_index:]]

--- a/app/matchtools/location_match.py
+++ b/app/matchtools/location_match.py
@@ -43,17 +43,15 @@ def create_master_location(geo_names_location: dict, hierarchy_location: MasterL
     return (master_location, created)
 
 def match_locations(master_location, source_location):
-    """Adds a master and source location to the locationRelation table"""
+    """Adds a master and source location to the LocationRelation table."""
 
     if master_location is None:
         raise ValueError("master_location cannot be None")
 
-    location_relation =  LocationRelation(
+    location_relation, _ = LocationRelation.objects.get_or_create(
         master_location=master_location,
-        source_location=source_location
+        source_location=source_location,
     )
-
-    location_relation.save()
     return location_relation
 
 def add_locations(geo_names_location, source_location_id):
@@ -94,8 +92,9 @@ def add_locations(geo_names_location, source_location_id):
         # if it was created or it was in the database already
         hierarchy_location = master_location
 
-    # If the location was succesfully added, match it with the source location
-    if added_locations and added_locations[-1] is not None:
-        match_locations(added_locations[-1], source_location)
+    # Match the source location with the final master location regardless of
+    # whether it was newly created or already existed in the database.
+    if hierarchy_location is not None:
+        match_locations(hierarchy_location, source_location)
 
     return added_locations

--- a/app/matchtools/location_match.py
+++ b/app/matchtools/location_match.py
@@ -92,6 +92,13 @@ def add_locations(geo_names_location, source_location_id):
         # if it was created or it was in the database already
         hierarchy_location = master_location
 
+    # Always include the final master location so the UI can display the
+    # matched location even if it already existed in the database.
+    if hierarchy_location is not None and (
+        not added_locations or added_locations[-1] != hierarchy_location
+    ):
+        added_locations.append(hierarchy_location)
+
     # Match the source location with the final master location regardless of
     # whether it was newly created or already existed in the database.
     if hierarchy_location is not None:

--- a/app/matchtools/views.py
+++ b/app/matchtools/views.py
@@ -14,7 +14,7 @@ from mb.views import user_is_data_admin_or_contributor
 
 from .filters import SourceAttributeFilter, SourceLocationFilter
 from .location_api import LocationAPI
-from .location_match import add_locations
+from .location_match import add_locations, get_hierarchy_chain
 
 
 @login_required
@@ -205,17 +205,14 @@ def match_location(request):
 
     # Add the master location and its hierarchy location(s) to the database
     locations = add_locations(geo_names_location, source_location_id)
-    
-    # If the matched locations was added, get the name of it
-    if locations and locations[-1] is not None:
-        matched_location = locations[-1].name
+
+    final_location = locations[-1] if locations else None
+
+    if final_location is not None:
+        matched_location = final_location.name
+        hierarchy_locations = get_hierarchy_chain(final_location)
     else:
         matched_location = None
-
-    # If any  hierarchy locations were added, get the name(s) of them
-    if locations and locations[0] is not None:
-        hierarchy_locations = [location.name for location in locations[:-1]]
-    else:
         hierarchy_locations = []
 
     return JsonResponse({

--- a/app/mb/templates/matchtool/location_match_detail.html
+++ b/app/mb/templates/matchtool/location_match_detail.html
@@ -13,6 +13,9 @@
 <section class="w3-threequarter w3-container">
   <header class="w3-row">
     <h2 class="w3-container w3-text-teal">Location Match: <span style="color: black;">{{ sourceLocation }}</span></h2>
+    {% if sourceLocation.reference %}
+      <div style="font-size: smaller; margin-top: -10px;">{{ sourceLocation.reference.citation }}</div>
+    {% endif %}
 
     <!--Search function-->
     <div class="w3-half" id="Search" style="display: block;">
@@ -155,7 +158,7 @@
     })
     .then(data => {
       document.querySelector('#masterLocation').innerHTML = data.masterLocation;
-      document.querySelector('#hierarchyLocations').innerHTML = data.hierarchy_locations.join(',<br>');
+      document.querySelector('#hierarchyLocations').innerHTML = data.hierarchy_locations.join('<br>');
 
       document.querySelector('#Search').style.display = 'none';
       document.querySelector('.mb-list').style.display = 'none';

--- a/app/mb/templates/matchtool/location_match_detail.html
+++ b/app/mb/templates/matchtool/location_match_detail.html
@@ -73,7 +73,7 @@
               <td style="text-align:center">-</td>
             {% endif %}
             {% if location.geonameId %}
-              <td><a href="https://www.geonames.org/{{ location.geonameId }}">{{ location.geonameId }}</a></td>
+              <td><a href="https://www.geonames.org/{{ location.geonameId }}" target="_blank" rel="noopener noreferrer">{{ location.geonameId }}</a></td>
             {% else %}
               <td style="text-align:center">-</td>
             {% endif %}


### PR DESCRIPTION
## Summary
- allow reusing an existing master location for matching
- always create or reuse a `LocationRelation`

## Testing
- `python app/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685ef0aa99fc8329a171c1610650ad36