### PR TITLE
Add tabs to master location detail view

### DIFF
--- a/app/mb/static/js/tabs.js
+++ b/app/mb/static/js/tabs.js
@@ -1,0 +1,15 @@
+function openTab(evt, tabName) {
+  var i, x, tablinks;
+  x = document.getElementsByClassName('tab');
+  for (i = 0; i < x.length; i++) {
+    x[i].style.display = 'none';
+  }
+  tablinks = document.getElementsByClassName('tablink');
+  for (i = 0; i < tablinks.length; i++) {
+    tablinks[i].classList.remove('w3-teal');
+  }
+  document.getElementById(tabName).style.display = 'block';
+  if (evt) {
+    evt.currentTarget.classList.add('w3-teal');
+  }
+}

--- a/app/mb/templates/mb/base_generic.html
+++ b/app/mb/templates/mb/base_generic.html
@@ -241,6 +241,7 @@
     </script>
       <noscript>Sorry, your browser does not support JavaScript!</noscript>
       <script src="{% static 'js/jquery-3.7.1.min.js' %}"></script>
+      <script src="{% static 'js/tabs.js' %}"></script>
       <script defer src="{% static 'js/cookieconsent-init.js' %}"></script>
     {% block script %}
     {% endblock %}

--- a/app/mb/templates/mb/master_location_detail.html
+++ b/app/mb/templates/mb/master_location_detail.html
@@ -10,11 +10,11 @@
 <!--End of article header -->
 
 <div class="w3-bar w3-border-bottom" style="margin-bottom:16px;">
-  <button class="w3-bar-item w3-button tablink w3-teal" onclick="openTab(event,'MasterTab')">Master</button>
-  <button class="w3-bar-item w3-button tablink" onclick="openTab(event,'SourceTab')">Source</button>
+  <button class="w3-bar-item w3-button tablink {% if not show_source_tab %}w3-teal{% endif %}" onclick="openTab(event,'MasterTab')">Master</button>
+  <button class="w3-bar-item w3-button tablink {% if show_source_tab %}w3-teal{% endif %}" onclick="openTab(event,'SourceTab')">Source</button>
 </div>
 
-<div id="MasterTab" class="tab" style="display:block">
+<div id="MasterTab" class="tab" style="display:{% if not show_source_tab %}block{% else %}none{% endif %}">
 <section class="w3-threequarter w3-container">
   <header class="w3-container w3-text-teal">
     <h2 style="display:none">Master Location: {{ master_location.name }}</h2>
@@ -124,7 +124,7 @@
       </section>
 </div>
 
-<div id="SourceTab" class="tab" style="display:none">
+<div id="SourceTab" class="tab" style="display:{% if show_source_tab %}block{% else %}none{% endif %}">
 <section class="w3-threequarter w3-container">
   <header class="w3-container w3-text-teal">
     <h2>Matched Source Locations</h2>
@@ -160,20 +160,4 @@
 {% endblock %}
 {% block pagination %}
 {% endblock %}
-{% block script %}
-<script>
-function openTab(evt, tabName) {
-  var i, x, tablinks;
-  x = document.getElementsByClassName('tab');
-  for (i = 0; i < x.length; i++) {
-    x[i].style.display = 'none';
-  }
-  tablinks = document.getElementsByClassName('tablink');
-  for (i = 0; i < tablinks.length; i++) {
-    tablinks[i].classList.remove('w3-teal');
-  }
-  document.getElementById(tabName).style.display = 'block';
-  evt.currentTarget.classList.add('w3-teal');
-}
-</script>
-{% endblock %}
+{% block script %}{% endblock %}

--- a/app/mb/templates/mb/master_location_detail.html
+++ b/app/mb/templates/mb/master_location_detail.html
@@ -94,34 +94,8 @@
         <th class="w3-quarter">State Province</th>
         <td class="w3-threequarter">{{ master_location.state_province }}</td>
       </tr>
-      </table>
-      {% if master_location.locationrelation_set.count > 0 %}
-        <table class="mb-detail w3-table-all">
-        {% for relation in master_location.locationrelation_set.all %}
-          <caption class="w3-left-align">Location Match</caption>
-          {% if relation.relation.name == "Location Match" and relation.is_active %}
-            <tr>
-              <th class="w3-quarter w3-text-teal">Master Location:</th>
-              <td class="w3-threequarter">{{ relation.master_location.name }}</td>
-            </tr>
-            <tr>
-              <th class="w3-quarter w3-text-teal">Reference:</th>
-              <td class="w3-threequarter">{{ relation.master_location.reference }}</td>
-            </tr>
-            <tr>
-              <th class="w3-quarter w3-text-teal">Match:</th>
-              <td class="w3-threequarter">{{ relation.relation_status.name }}</td>
-          </tr>
-          <tr>
-            <th class="w3-quarter w3-text-teal">Status:</th>
-            <td class="w3-threequarter">{{ relation.data_status.name }}</td>
-          </tr>
-          {% endif %}
-        {% endfor %}
-        </table>
-      {% else %}
-      {% endif %}
-      </section>
+  </table>
+</section>
 </div>
 
 <div id="SourceTab" class="tab" style="display:{% if show_source_tab %}block{% else %}none{% endif %}">

--- a/app/mb/templates/mb/master_location_detail.html
+++ b/app/mb/templates/mb/master_location_detail.html
@@ -8,6 +8,13 @@
   <h1>MammalBase - Master Location: {{ master_location.name }}</h1>
 </header>
 <!--End of article header -->
+
+<div class="w3-bar w3-border-bottom" style="margin-bottom:16px;">
+  <button class="w3-bar-item w3-button tablink w3-teal" onclick="openTab(event,'MasterTab')">Master</button>
+  <button class="w3-bar-item w3-button tablink" onclick="openTab(event,'SourceTab')">Source</button>
+</div>
+
+<div id="MasterTab" class="tab" style="display:block">
 <section class="w3-threequarter w3-container">
   <header class="w3-container w3-text-teal">
     <h2 style="display:none">Master Location: {{ master_location.name }}</h2>
@@ -112,13 +119,61 @@
           {% endif %}
         {% endfor %}
         </table>
-    {% else %}
-    {% endif %}
-    </section>
+      {% else %}
+      {% endif %}
+      </section>
+</div>
+
+<div id="SourceTab" class="tab" style="display:none">
+<section class="w3-threequarter w3-container">
+  <header class="w3-container w3-text-teal">
+    <h2>Matched Source Locations</h2>
+  </header>
+
+  {% include 'includes/find.html' %}
+
+  {% if page_obj %}
+  <table class="mb-list w3-table-all w3-small w3-responsive">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Reference</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for sl in page_obj %}
+      <tr>
+        <td>{{ sl.name }}</td>
+        <td>{{ sl.reference }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% else %}
+    <p>There are no matched source locations.</p>
+  {% endif %}
+</section>
+</div>
+
 {% endblock %}
 {% block info %}
 {% endblock %}
 {% block pagination %}
 {% endblock %}
 {% block script %}
+<script>
+function openTab(evt, tabName) {
+  var i, x, tablinks;
+  x = document.getElementsByClassName('tab');
+  for (i = 0; i < x.length; i++) {
+    x[i].style.display = 'none';
+  }
+  tablinks = document.getElementsByClassName('tablink');
+  for (i = 0; i < tablinks.length; i++) {
+    tablinks[i].classList.remove('w3-teal');
+  }
+  document.getElementById(tabName).style.display = 'block';
+  evt.currentTarget.classList.add('w3-teal');
+}
+</script>
 {% endblock %}

--- a/app/mb/views/unsorted.py
+++ b/app/mb/views/unsorted.py
@@ -2159,6 +2159,8 @@ def master_location_detail(request, pk):
     except EmptyPage:
         page_obj = paginator.page(paginator.num_pages)
 
+    show_source_tab = bool(request.GET)
+
     return render(
         request,
         'mb/master_location_detail.html',
@@ -2166,6 +2168,7 @@ def master_location_detail(request, pk):
             'master_location': master_location,
             'filter': filter,
             'page_obj': page_obj,
+            'show_source_tab': show_source_tab,
         },
     )
 

--- a/app/mb/views/unsorted.py
+++ b/app/mb/views/unsorted.py
@@ -51,6 +51,7 @@ from mb.filters import (
     ProximateAnalysisFilter,
     ProximateAnalysisItemFilter,
     SourceAttributeFilter,
+    SourceLocationFilter,
     SourceEntityFilter,
     SourceReferenceFilter,
     TaxonomicUnitsFilter,
@@ -103,6 +104,8 @@ from mb.models import (
     SourceEntity,
     SourceMeasurementValue,
     SourceReference,
+    SourceLocation,
+    LocationRelation,
     TimePeriod,
     ViewProximateAnalysisTable)
 
@@ -2138,9 +2141,33 @@ def index_master_location_listx(request):
 
 def master_location_detail(request, pk):
     master_location = get_object_or_404(MasterLocation, pk=pk, is_active=1)
-    return render(request,
-                  'mb/master_location_detail.html',
-                  {'master_location': master_location})
+
+    filter = SourceLocationFilter(
+        request.GET,
+        queryset=SourceLocation.objects.filter(
+            locationrelation__master_location=master_location,
+            locationrelation__is_active=True,
+        ).select_related('reference').distinct(),
+    )
+
+    paginator = Paginator(filter.qs, 10)
+    page_number = request.GET.get('page')
+    try:
+        page_obj = paginator.page(page_number)
+    except PageNotAnInteger:
+        page_obj = paginator.page(1)
+    except EmptyPage:
+        page_obj = paginator.page(paginator.num_pages)
+
+    return render(
+        request,
+        'mb/master_location_detail.html',
+        {
+            'master_location': master_location,
+            'filter': filter,
+            'page_obj': page_obj,
+        },
+    )
 
 # THIS IS NOT USED, CAN BE DELETED
 def master_location_detailx(request, pk):


### PR DESCRIPTION
## Summary
- add SourceLocationFilter to imports
- show Source Locations in a new tab on the master location detail page
- support filtering & pagination for the source location list
- implement tabbed interface using w3.css

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68604b44929083298f9d054ed869b6f5