### PR TITLE
Fix editing buttons on master location

### DIFF
--- a/app/mb/templates/mb/master_location_detail.html
+++ b/app/mb/templates/mb/master_location_detail.html
@@ -23,8 +23,8 @@
   <div class="mb-detail w3-bar w3-right-align">
     <a title="Press to Go Back" class="w3-button w3-medium w3-round w3-padding-small w3-teal" onclick="backFunction()"><span class="fa fa-arrow-left"></span></a>
     {% if request.user|is_data_admin_or_owner:master_location %}
-    <button title="Please login to Edit" class="w3-disabled w3-button w3-medium w3-round w3-padding-small w3-teal"><span class="fa fa-pencil-square-o"></span></button>
-    <button title="Please login to Delete" class="w3-disabled w3-button w3-medium w3-round w3-padding-small w3-teal"><span class="fa  fa-trash-o"></span></button>
+    <a title="Press to Edit" class="w3-button w3-medium w3-round w3-padding-small w3-teal" href="{% url 'master_location-edit' pk=master_location.pk %}"><span class="fa fa-pencil-square-o"></span></a>
+    <a title="Press to Delete" class="w3-button w3-medium w3-round w3-padding-small w3-teal" href="{% url 'master_location-delete' pk=master_location.pk %}"><span class="fa  fa-trash-o"></span></a>
     {% else %}
     <button title="Please login to Edit" class="w3-disabled w3-button w3-medium w3-round w3-padding-small w3-teal"><span class="fa fa-pencil-square-o"></span></button>
     <button title="Please login to Delete" class="w3-disabled w3-button w3-medium w3-round w3-padding-small w3-teal"><span class="fa  fa-trash-o"></span></button>


### PR DESCRIPTION
## Summary
- show Edit/Delete links on `ml_detail` pages when authorized

## Testing
- `python3 app/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68605b6e83808329835e4b3e6f0c41e9