### PR TITLE
Rename template filter function

### DIFF
--- a/app/mb/templatetags/custom_tags.py
+++ b/app/mb/templatetags/custom_tags.py
@@ -9,7 +9,9 @@ from django.contrib.auth.models import Group
 register = template.Library()
 
 @register.filter(name='is_data_admin_or_contributor')
-def is_data_admin_or_owner(user):
+def is_data_admin_or_contributor(user):
+    """Return True if the user belongs to the data_admin or
+    data_contributor group."""
     if user.groups.filter(name='data_admin').exists():
         return True
 


### PR DESCRIPTION
## Summary
- rename `is_data_admin_or_owner` helper to `is_data_admin_or_contributor`
- document what the helper returns
- ensure the file ends with a newline

## Testing
- `python3 -m py_compile app/mb/templatetags/custom_tags.py`


------
https://chatgpt.com/codex/tasks/task_e_68605f5345948329b2c8e3178b075744