### PR TITLE
Fix missing master location edit URL

### DIFF
--- a/app/mb/forms/__init__.py
+++ b/app/mb/forms/__init__.py
@@ -14,6 +14,7 @@ from .main import (
     MasterChoiceSetOptionForm,
     MasterEntityForm,
     MasterReferenceForm,
+    MasterLocationForm,
     OrderingForm,
     SourceAttributeChoicesetOptionForm,
     SourceAttributeForm,

--- a/app/mb/forms/main.py
+++ b/app/mb/forms/main.py
@@ -15,6 +15,7 @@ from mb.models import (
     MasterReference,
     ProximateAnalysis,
     ProximateAnalysisItem,
+    MasterLocation,
     SourceAttribute,
     SourceChoiceSetOption,
     SourceChoiceSetOptionValue,
@@ -107,6 +108,12 @@ class MasterReferenceForm(forms.ModelForm):
     class Meta:
         model = MasterReference
         fields = ('type', 'first_author', 'year', 'title', 'container_title', 'volume', 'issue', 'page', 'citation', 'doi', 'uri',)
+
+class MasterLocationForm(forms.ModelForm):
+    class Meta:
+        model = MasterLocation
+        fields = ('name', 'reference', 'continent', 'country', 'country_code', 'decimal_latitude', 'decimal_longitude', 'geodetic_datum')
+        widgets = {'reference': ReferenceWidget, }
 
 # Sortable, see. https://nemecek.be/blog/4/django-how-to-let-user-re-ordersort-table-of-content-with-drag-and-drop
 class OrderingForm(forms.Form):

--- a/app/mb/templates/mb/master_location_detail.html
+++ b/app/mb/templates/mb/master_location_detail.html
@@ -62,7 +62,7 @@
       </tr>
       <tr>
         <th class="w3-quarter">Location ID</th>
-        <td class="w3-threequarter"><a title="Press for Details"
+        <td class="w3-threequarter"><a title="Press for Details" target="_blank"
           href="https://geonames.org/{{ master_location.location_id }}">{{ master_location.location_id }}<span class="fa fa-link w3-small"></span></a></td>
       </tr>
       <tr>

--- a/app/mb/templates/mb/master_location_edit.html
+++ b/app/mb/templates/mb/master_location_edit.html
@@ -1,0 +1,34 @@
+{% extends 'mb/base_generic.html' %}
+
+{% block script %}
+<!-- Used for Django select2 -->
+  {{ form.media.js }}
+{% endblock %}
+
+{% block title %}
+  <title>MammalBase - Add/Edit Master Location</title>
+{% endblock %}
+{% block content %} {% load custom_tags %}
+  <!--Article header -->
+  <header style="display:none">
+    <h1>MammalBase - Add/Edit Master Location</h1>
+  </header>
+  <!--End of article header -->
+  <section class="w3-threequarter w3-container">
+    <header class="w3-container w3-text-teal">
+      <h2>Add/Edit Master Location</h2>
+    </header>
+	{% if request.user|is_data_admin_or_contributor %}
+      <form method="POST" novalidate>
+        {% csrf_token %}
+        {% include 'includes/w3c-form.html' with form=form %}
+        <div class="mb-detail w3-bar w3-right-align">
+          <a title="Press to Go Back" class="w3-button w3-medium w3-round w3-padding-small w3-teal" onclick="backFunction()"><span class="fa fa-arrow-left"></span></a>
+          <button title="Press to Submit" type="submit" class="w3-button w3-medium w3-round w3-padding-small w3-teal">Submit&nbsp; <i class="fa fa-angle-right"></i><i class="fa fa-angle-right"></i></button>
+        </div>
+      </form>
+    {% else %}
+      <p><a href="{% url 'login'%}?next={{request.path}}">Please login first</a></p>
+    {% endif %}
+  </section>
+{% endblock %}

--- a/app/mb/templates/mb/master_location_edit.html
+++ b/app/mb/templates/mb/master_location_edit.html
@@ -28,7 +28,7 @@
         </div>
       </form>
     {% else %}
-      <p><a href="{% url 'login'%}?next={{request.path}}">Please login first</a></p>
+      <p><a href="{% url 'account_login'%}?next={{request.path}}">Please login first</a></p>
     {% endif %}
   </section>
 {% endblock %}

--- a/app/mb/templates/mb/masterlocation_confirm_delete.html
+++ b/app/mb/templates/mb/masterlocation_confirm_delete.html
@@ -1,0 +1,16 @@
+{% extends 'mb/base_generic.html' %}
+{% block content %} {% load custom_tags %}
+  {% if request.user|is_data_admin_or_owner:master_location %}
+    <h1>Delete Master Location</h1>
+
+    <p>Are you sure you want to delete the Master Location: <b><i>{{ master_location }}</i></b>?</p>
+
+    <form action="" method="POST">
+        {% csrf_token %}
+        <input type="submit" action="" value="Yes, delete." />
+    </form>
+    <p><a onclick="backFunction()">Go back</a></p>
+  {% else %}
+    <p><a href="{% url 'login'%}?next={{request.path}}">Please login first</a></p>
+  {% endif %}
+{% endblock %}

--- a/app/mb/templates/mb/masterlocation_confirm_delete.html
+++ b/app/mb/templates/mb/masterlocation_confirm_delete.html
@@ -11,6 +11,6 @@
     </form>
     <p><a onclick="backFunction()">Go back</a></p>
   {% else %}
-    <p><a href="{% url 'login'%}?next={{request.path}}">Please login first</a></p>
+    <p><a href="{% url 'account_login'%}?next={{request.path}}">Please login first</a></p>
   {% endif %}
 {% endblock %}

--- a/app/mb/templates/mb/masterlocation_confirm_delete.html
+++ b/app/mb/templates/mb/masterlocation_confirm_delete.html
@@ -1,9 +1,9 @@
 {% extends 'mb/base_generic.html' %}
 {% block content %} {% load custom_tags %}
-  {% if request.user|is_data_admin_or_owner:master_location %}
+  {% if request.user|is_data_admin_or_owner:masterlocation %}
     <h1>Delete Master Location</h1>
 
-    <p>Are you sure you want to delete the Master Location: <b><i>{{ master_location }}</i></b>?</p>
+    <p>Are you sure you want to delete the Master Location: <b><i>{{ masterlocation }}</i></b>?</p>
 
     <form action="" method="POST">
         {% csrf_token %}

--- a/app/mb/views/__init__.py
+++ b/app/mb/views/__init__.py
@@ -113,4 +113,6 @@ from .unsorted import (
     tsn_search,
     view_proximate_analysis_table_list,
     index_master_location_list,
+    master_location_edit,
+    MasterLocationDelete,
     master_location_detail)

--- a/app/urls/unsorted.py
+++ b/app/urls/unsorted.py
@@ -25,6 +25,14 @@ urlpatterns = [
         views.master_location_detail,
         name="master_location_detail"),
     path(
+        "ml/<int:pk>/delete/",
+        views.MasterLocationDelete.as_view(),
+        name="master_location-delete"),
+    path(
+        "ml/<int:pk>/edit/",
+        views.master_location_edit,
+        name="master_location-edit"),
+    path(
 	    'ipa',
 	    views.index_proximate_analysis,
 	    name='index_proximate_analysis'),


### PR DESCRIPTION
## Summary
- allow editing and deleting master locations
- add MasterLocationForm and templates
- expose new views through view init and unsorted urls

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6861847508048329af224c0f9af8e564