### PR TITLE
Add occurrence list to master location page

### DIFF
--- a/app/mb/templates/mb/master_location_detail.html
+++ b/app/mb/templates/mb/master_location_detail.html
@@ -12,6 +12,7 @@
 <div class="w3-bar w3-border-bottom" style="margin-bottom:16px;">
   <button class="w3-bar-item w3-button tablink {% if not show_source_tab %}w3-teal{% endif %}" onclick="openTab(event,'MasterTab')">Master</button>
   <button class="w3-bar-item w3-button tablink {% if show_source_tab %}w3-teal{% endif %}" onclick="openTab(event,'SourceTab')">Source</button>
+  <button class="w3-bar-item w3-button tablink" onclick="openTab(event,'OccurrenceTab')">Occurrences</button>
 </div>
 
 <div id="MasterTab" class="tab" style="display:{% if not show_source_tab %}block{% else %}none{% endif %}">
@@ -116,6 +117,37 @@
   </table>
   {% else %}
     <p>There are no matched source locations.</p>
+  {% endif %}
+</section>
+</div>
+
+<div id="OccurrenceTab" class="tab" style="display:none;">
+<section class="w3-threequarter w3-container">
+  <header class="w3-container w3-text-teal">
+    <h2>Occurrences</h2>
+  </header>
+
+  {% if occurrences %}
+  <table class="mb-list w3-table-all w3-small w3-responsive">
+    <thead>
+      <tr>
+        <th>Taxon</th>
+        <th>Rank</th>
+        <th>Higher Classification</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for me in occurrences %}
+      <tr>
+        <td class="mb-public-internal"><a title="Press for Details" href="{% url 'master_entity-detail' pk=me.pk %}">{{ me.name }} <span class="fa fa-link w3-small"></span></a></td>
+        <td>{{ me.entity }}</td>
+        <td>{{ me.taxon.higher_classification }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% else %}
+    <p>There are no occurrences.</p>
   {% endif %}
 </section>
 </div>

--- a/app/mb/views/unsorted.py
+++ b/app/mb/views/unsorted.py
@@ -2165,13 +2165,13 @@ def master_location_detail(request, pk):
     occurrences = MasterEntity.objects.is_active().filter(
         entityrelation__is_active=True,
         entityrelation__source_entity__is_active=True,
-        entityrelation__source_entity__occurrence__is_active=True,
-        entityrelation__source_entity__occurrence__source_location__is_active=True,
-        entityrelation__source_entity__occurrence__source_location__locationrelation__is_active=True,
-        entityrelation__source_entity__occurrence__source_location__locationrelation__master_location=master_location,
-        entityrelation__source_entity__occurrence__source_reference__is_active=True,
-        entityrelation__source_entity__occurrence__source_reference__referencerelation__is_active=True,
-        entityrelation__source_entity__occurrence__source_reference__referencerelation__master_reference__is_active=True,
+        entityrelation__source_entity__taxon_occurrence__is_active=True,
+        entityrelation__source_entity__taxon_occurrence__source_location__is_active=True,
+        entityrelation__source_entity__taxon_occurrence__source_location__locationrelation__is_active=True,
+        entityrelation__source_entity__taxon_occurrence__source_location__locationrelation__master_location=master_location,
+        entityrelation__source_entity__taxon_occurrence__source_reference__is_active=True,
+        entityrelation__source_entity__taxon_occurrence__source_reference__referencerelation__is_active=True,
+        entityrelation__source_entity__taxon_occurrence__source_reference__referencerelation__master_reference__is_active=True,
     ).select_related('entity', 'taxon').order_by('name').distinct()
 
     return render(

--- a/app/mb/views/unsorted.py
+++ b/app/mb/views/unsorted.py
@@ -2162,6 +2162,18 @@ def master_location_detail(request, pk):
 
     show_source_tab = bool(request.GET)
 
+    occurrences = MasterEntity.objects.is_active().filter(
+        entityrelation__is_active=True,
+        entityrelation__source_entity__is_active=True,
+        entityrelation__source_entity__occurrence__is_active=True,
+        entityrelation__source_entity__occurrence__source_location__is_active=True,
+        entityrelation__source_entity__occurrence__source_location__locationrelation__is_active=True,
+        entityrelation__source_entity__occurrence__source_location__locationrelation__master_location=master_location,
+        entityrelation__source_entity__occurrence__source_reference__is_active=True,
+        entityrelation__source_entity__occurrence__source_reference__referencerelation__is_active=True,
+        entityrelation__source_entity__occurrence__source_reference__referencerelation__master_reference__is_active=True,
+    ).select_related('entity', 'taxon').order_by('name').distinct()
+
     return render(
         request,
         'mb/master_location_detail.html',
@@ -2170,6 +2182,7 @@ def master_location_detail(request, pk):
             'filter': filter,
             'page_obj': page_obj,
             'show_source_tab': show_source_tab,
+            'occurrences': occurrences,
         },
     )
 

--- a/app/mb/views/unsorted.py
+++ b/app/mb/views/unsorted.py
@@ -2170,9 +2170,8 @@ def master_location_detail(request, pk):
         entityrelation__source_entity__taxon_occurrence__source_location__locationrelation__is_active=True,
         entityrelation__source_entity__taxon_occurrence__source_location__locationrelation__master_location=master_location,
         entityrelation__source_entity__taxon_occurrence__source_reference__is_active=True,
-        entityrelation__source_entity__taxon_occurrence__source_reference__referencerelation__is_active=True,
-        entityrelation__source_entity__taxon_occurrence__source_reference__referencerelation__master_reference__is_active=True,
-    ).select_related('entity', 'taxon').order_by('name').distinct()
+        entityrelation__source_entity__taxon_occurrence__source_reference__master_reference__is_active=True,
+    ).select_related('entity', 'taxon').order_by('taxon__higher_classification').distinct()
 
     return render(
         request,


### PR DESCRIPTION
## Summary
- show occurrences for each master location
- query master entities with active relations
- display occurrences on a new tab

## Testing
- `python app/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686199907d948329b09a9826d55372af