### PR TITLE
Add occurrence details popup

### DIFF
--- a/app/mb/templates/mb/master_location_detail.html
+++ b/app/mb/templates/mb/master_location_detail.html
@@ -158,6 +158,11 @@
 </section>
 </div>
 
+<div id="occ-detail-modal" class="w3-modal" style="display:none;">
+  <div class="w3-modal-content w3-padding" id="occ-detail-content">
+  </div>
+</div>
+
 {% endblock %}
 {% block info %}
 {% endblock %}
@@ -166,9 +171,17 @@
 {% block script %}
 <script>
   function openOccurrenceDetails(mlId, meId) {
-    var url = "{% url 'occurrence_details' 0 0 %}";
-    url = url.replace('0/0', mlId + '/' + meId);
-    window.open(url, '_blank', 'width=600,height=600');
+    var url = "{% url 'occurrence_details' 0 0 %}".replace('0/0', mlId + '/' + meId);
+    fetch(url)
+      .then(function (response) { return response.text(); })
+      .then(function (html) {
+        document.getElementById('occ-detail-content').innerHTML = html;
+        document.getElementById('occ-detail-modal').style.display = 'block';
+      });
+  }
+
+  function closeOccDetails() {
+    document.getElementById('occ-detail-modal').style.display = 'none';
   }
 </script>
 {% endblock %}

--- a/app/mb/templates/mb/master_location_detail.html
+++ b/app/mb/templates/mb/master_location_detail.html
@@ -134,6 +134,7 @@
         <th>Taxon</th>
         <th>Rank</th>
         <th>Higher Classification</th>
+        <th>Details</th>
       </tr>
     </thead>
     <tbody>
@@ -142,6 +143,11 @@
         <td class="mb-public-internal"><a title="Press for Details" href="{% url 'master_entity-detail' pk=me.pk %}">{{ me.name }} <span class="fa fa-link w3-small"></span></a></td>
         <td>{{ me.entity }}</td>
         <td>{{ me.taxon.higher_classification }}</td>
+        <td class="w3-center">
+          <button class="w3-button w3-small" title="Show Details" onclick="openOccurrenceDetails({{ master_location.id }}, {{ me.id }})">
+            <span class="fa fa-search"></span>
+          </button>
+        </td>
       </tr>
       {% endfor %}
     </tbody>
@@ -157,4 +163,12 @@
 {% endblock %}
 {% block pagination %}
 {% endblock %}
-{% block script %}{% endblock %}
+{% block script %}
+<script>
+  function openOccurrenceDetails(mlId, meId) {
+    var url = "{% url 'occurrence_details' 0 0 %}";
+    url = url.replace('0/0', mlId + '/' + meId);
+    window.open(url, '_blank', 'width=600,height=600');
+  }
+</script>
+{% endblock %}

--- a/app/mb/templates/mb/occurrence_details.html
+++ b/app/mb/templates/mb/occurrence_details.html
@@ -1,0 +1,65 @@
+{% extends "mb/base_generic.html" %}
+{% block title %}
+<title>Occurrence Details</title>
+{% endblock %}
+{% block content %}
+<section class="w3-container w3-margin">
+  <header class="w3-container w3-text-teal">
+    <h2>Occurrence Details</h2>
+  </header>
+  <table class="mb-list w3-table-all w3-small">
+    <caption class="w3-left-align">
+      Master Location: {{ master_location.name }}<br>
+      Master Entity: {{ master_entity.name }}
+    </caption>
+    <tbody>
+      {% for occ in occurrences %}
+        <tr class="w3-light-grey">
+          <th colspan="2">Occurrence {{ forloop.counter }}</th>
+        </tr>
+        <tr>
+          <th class="w3-quarter">Source Entity</th>
+          <td class="w3-threequarter">{{ occ.source_entity.name }}</td>
+        </tr>
+        <tr>
+          <th class="w3-quarter">Source Location</th>
+          <td class="w3-threequarter">{{ occ.source_location.name }}</td>
+        </tr>
+        <tr>
+          <th class="w3-quarter">Reference</th>
+          <td class="w3-threequarter">{{ occ.source_reference.citation }}</td>
+        </tr>
+        <tr>
+          <th class="w3-quarter">Event Date</th>
+          <td class="w3-threequarter">{% if occ.event %}{{ occ.event.verbatim_event_date }}{% else %}-{% endif %}</td>
+        </tr>
+        <tr>
+          <th class="w3-quarter">Gender</th>
+          <td class="w3-threequarter">{{ occ.gender.caption|default_if_none:"-" }}</td>
+        </tr>
+        <tr>
+          <th class="w3-quarter">Life Stage</th>
+          <td class="w3-threequarter">{{ occ.life_stage.caption|default_if_none:"-" }}</td>
+        </tr>
+        <tr>
+          <th class="w3-quarter">Organism Quantity</th>
+          <td class="w3-threequarter">
+            {% if occ.organism_quantity %}{{ occ.organism_quantity }}{% else %}-{% endif %}
+            {% if occ.organism_quantity_type %} {{ occ.organism_quantity_type }}{% endif %}
+          </td>
+        </tr>
+        <tr>
+          <th class="w3-quarter">Remarks</th>
+          <td class="w3-threequarter">{{ occ.occurrence_remarks|default_if_none:"-" }}</td>
+        </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% if not occurrences %}
+    <p>No occurrence details available.</p>
+  {% endif %}
+</section>
+{% endblock %}
+{% block info %}{% endblock %}
+{% block pagination %}{% endblock %}
+{% block script %}{% endblock %}

--- a/app/mb/templates/mb/occurrence_details.html
+++ b/app/mb/templates/mb/occurrence_details.html
@@ -26,8 +26,20 @@
           <td class="w3-threequarter">{{ occ.source_reference.citation }}</td>
         </tr>
         <tr>
-          <th class="w3-quarter">Event Date</th>
+          <th class="w3-quarter">Verbatim Event Date</th>
           <td class="w3-threequarter">{% if occ.event %}{{ occ.event.verbatim_event_date }}{% else %}-{% endif %}</td>
+        </tr>
+        <tr>
+          <th class="w3-quarter">Source Method</th>
+          <td class="w3-threequarter">{% if occ.event and occ.event.source_method %}{{ occ.event.source_method.name }}{% else %}-{% endif %}</td>
+        </tr>
+        <tr>
+          <th class="w3-quarter">Habitat Type</th>
+          <td class="w3-threequarter">{% if occ.event and occ.event.source_habitat %}{{ occ.event.source_habitat.habitat_type|default_if_none:"-" }}{% else %}-{% endif %}</td>
+        </tr>
+        <tr>
+          <th class="w3-quarter">Habitat Percentage</th>
+          <td class="w3-threequarter">{% if occ.event and occ.event.source_habitat %}{{ occ.event.source_habitat.habitat_percentage|default_if_none:"-" }}{% else %}-{% endif %}</td>
         </tr>
         <tr>
           <th class="w3-quarter">Gender</th>
@@ -41,8 +53,15 @@
           <th class="w3-quarter">Organism Quantity</th>
           <td class="w3-threequarter">
             {% if occ.organism_quantity %}{{ occ.organism_quantity }}{% else %}-{% endif %}
-            {% if occ.organism_quantity_type %} {{ occ.organism_quantity_type }}{% endif %}
           </td>
+        </tr>
+        <tr>
+          <th class="w3-quarter">Organism Quantity Type</th>
+          <td class="w3-threequarter">{{ occ.organism_quantity_type|default_if_none:"-" }}</td>
+        </tr>
+        <tr>
+          <th class="w3-quarter">Associated References</th>
+          <td class="w3-threequarter">{{ occ.associated_references|default_if_none:"-" }}</td>
         </tr>
         <tr>
           <th class="w3-quarter">Remarks</th>
@@ -54,4 +73,7 @@
   {% if not occurrences %}
     <p>No occurrence details available.</p>
   {% endif %}
+  <div class="w3-center">
+    <button onclick="closeOccDetails()" class="w3-button w3-margin">&times; Close</button>
+  </div>
 </div>

--- a/app/mb/templates/mb/occurrence_details.html
+++ b/app/mb/templates/mb/occurrence_details.html
@@ -1,3 +1,4 @@
+{% load custom_tags %}
 <div class="w3-container w3-margin">
   <header class="w3-container w3-text-teal">
     <h3>Occurrence Details</h3>
@@ -22,8 +23,32 @@
           <td class="w3-threequarter">{{ occ.source_location.name }}</td>
         </tr>
         <tr>
-          <th class="w3-quarter">Reference</th>
-          <td class="w3-threequarter">{{ occ.source_reference.citation }}</td>
+          <th class="w3-quarter">Verbatim Elevation</th>
+          <td class="w3-threequarter">{{ occ.source_location.verbatim_elevation|default_if_none:"-" }}</td>
+        </tr>
+        <tr>
+          <th class="w3-quarter">Verbatim Depth</th>
+          <td class="w3-threequarter">{{ occ.source_location.verbatim_depth|default_if_none:"-" }}</td>
+        </tr>
+        <tr>
+          <th class="w3-quarter">Verbatim Coordinates</th>
+          <td class="w3-threequarter">{{ occ.source_location.verbatim_coordinates|default_if_none:"-" }}</td>
+        </tr>
+        <tr>
+          <th class="w3-quarter">Verbatim Latitude</th>
+          <td class="w3-threequarter">{{ occ.source_location.verbatim_latitude|default_if_none:"-" }}</td>
+        </tr>
+        <tr>
+          <th class="w3-quarter">Verbatim Longitude</th>
+          <td class="w3-threequarter">{{ occ.source_location.verbatim_longitude|default_if_none:"-" }}</td>
+        </tr>
+        <tr>
+          <th class="w3-quarter">Verbatim Coordinate System</th>
+          <td class="w3-threequarter">{{ occ.source_location.verbatim_coordinate_system|default_if_none:"-" }}</td>
+        </tr>
+        <tr>
+          <th class="w3-quarter">Verbatim SRS</th>
+          <td class="w3-threequarter">{{ occ.source_location.verbatim_srs|default_if_none:"-" }}</td>
         </tr>
         <tr>
           <th class="w3-quarter">Verbatim Event Date</th>
@@ -51,9 +76,7 @@
         </tr>
         <tr>
           <th class="w3-quarter">Organism Quantity</th>
-          <td class="w3-threequarter">
-            {% if occ.organism_quantity %}{{ occ.organism_quantity }}{% else %}-{% endif %}
-          </td>
+          <td class="w3-threequarter">{{ occ.organism_quantity|int_or_dash }}</td>
         </tr>
         <tr>
           <th class="w3-quarter">Organism Quantity Type</th>
@@ -67,13 +90,17 @@
           <th class="w3-quarter">Remarks</th>
           <td class="w3-threequarter">{{ occ.occurrence_remarks|default_if_none:"-" }}</td>
         </tr>
+        <tr>
+          <th class="w3-quarter">Reference</th>
+          <td class="w3-threequarter">{{ occ.source_reference.citation }}</td>
+        </tr>
       {% endfor %}
     </tbody>
   </table>
   {% if not occurrences %}
     <p>No occurrence details available.</p>
   {% endif %}
-  <div class="w3-center">
-    <button onclick="closeOccDetails()" class="w3-button w3-margin">&times; Close</button>
+  <div class="w3-container">
+    <button onclick="closeOccDetails()" class="w3-button w3-right w3-margin">&times; Close</button>
   </div>
 </div>

--- a/app/mb/templates/mb/occurrence_details.html
+++ b/app/mb/templates/mb/occurrence_details.html
@@ -1,11 +1,7 @@
-{% extends "mb/base_generic.html" %}
-{% block title %}
-<title>Occurrence Details</title>
-{% endblock %}
-{% block content %}
-<section class="w3-container w3-margin">
+<div class="w3-container w3-margin">
   <header class="w3-container w3-text-teal">
-    <h2>Occurrence Details</h2>
+    <h3>Occurrence Details</h3>
+    <button onclick="closeOccDetails()" class="w3-button w3-right w3-margin">&times; Close</button>
   </header>
   <table class="mb-list w3-table-all w3-small">
     <caption class="w3-left-align">
@@ -14,8 +10,8 @@
     </caption>
     <tbody>
       {% for occ in occurrences %}
-        <tr class="w3-light-grey">
-          <th colspan="2">Occurrence {{ forloop.counter }}</th>
+        <tr class="w3-dark-grey">
+          <th colspan="2" class="w3-center">Occurrence {{ forloop.counter }}</th>
         </tr>
         <tr>
           <th class="w3-quarter">Source Entity</th>
@@ -58,8 +54,4 @@
   {% if not occurrences %}
     <p>No occurrence details available.</p>
   {% endif %}
-</section>
-{% endblock %}
-{% block info %}{% endblock %}
-{% block pagination %}{% endblock %}
-{% block script %}{% endblock %}
+</div>

--- a/app/mb/templatetags/custom_tags.py
+++ b/app/mb/templatetags/custom_tags.py
@@ -5,6 +5,7 @@
 
 from django import template
 from django.contrib.auth.models import Group
+import math
 
 register = template.Library()
 
@@ -42,3 +43,16 @@ def trim_gender(value):
 @register.filter(name="trim_lifestage")
 def trim_lifestage(value):
     return value.replace("LifeStage -", "")
+
+@register.filter(name="int_or_dash")
+def int_or_dash(value):
+    """Return integer representation of value or '-' for invalid values."""
+    if value in (None, "", "nan", "NaN"):
+        return "-"
+    try:
+        number = float(value)
+    except (ValueError, TypeError):
+        return "-"
+    if math.isnan(number):
+        return "-"
+    return str(int(number))

--- a/app/mb/views/__init__.py
+++ b/app/mb/views/__init__.py
@@ -115,4 +115,5 @@ from .unsorted import (
     index_master_location_list,
     master_location_edit,
     MasterLocationDelete,
-    master_location_detail)
+    master_location_detail,
+    occurrence_details)

--- a/app/mb/views/unsorted.py
+++ b/app/mb/views/unsorted.py
@@ -2242,6 +2242,8 @@ def occurrence_details(request, ml_pk, me_pk):
         'source_location',
         'source_entity',
         'event',
+        'event__source_method',
+        'event__source_habitat',
         'gender',
         'life_stage',
     ).distinct()

--- a/app/mb/views/unsorted.py
+++ b/app/mb/views/unsorted.py
@@ -108,6 +108,8 @@ from mb.models import (
     SourceLocation,
     LocationRelation,
     TimePeriod,
+    Occurrence,
+    Event,
     ViewProximateAnalysisTable)
 
 from mb.models.location import MasterLocation
@@ -2219,3 +2221,37 @@ def master_location_edit(request, pk):
     else:
         form = MasterLocationForm(instance=master_location)
     return render(request, 'mb/master_location_edit.html', {'form': form})
+
+
+def occurrence_details(request, ml_pk, me_pk):
+    """Return occurrence details for a master location and master entity."""
+    master_location = get_object_or_404(MasterLocation, pk=ml_pk, is_active=True)
+    master_entity = get_object_or_404(MasterEntity, pk=me_pk, is_active=True)
+
+    occurrences = Occurrence.objects.is_active().filter(
+        source_location__is_active=True,
+        source_location__locationrelation__is_active=True,
+        source_location__locationrelation__master_location=master_location,
+        source_entity__is_active=True,
+        source_entity__entityrelation__is_active=True,
+        source_entity__entityrelation__master_entity=master_entity,
+        source_reference__is_active=True,
+        source_reference__master_reference__is_active=True,
+    ).select_related(
+        'source_reference',
+        'source_location',
+        'source_entity',
+        'event',
+        'gender',
+        'life_stage',
+    ).distinct()
+
+    return render(
+        request,
+        'mb/occurrence_details.html',
+        {
+            'master_location': master_location,
+            'master_entity': master_entity,
+            'occurrences': occurrences,
+        },
+    )

--- a/app/urls/unsorted.py
+++ b/app/urls/unsorted.py
@@ -25,6 +25,10 @@ urlpatterns = [
         views.master_location_detail,
         name="master_location_detail"),
     path(
+        "occurrence_details/<int:ml_pk>/<int:me_pk>/",
+        views.occurrence_details,
+        name="occurrence_details"),
+    path(
         "ml/<int:pk>/delete/",
         views.MasterLocationDelete.as_view(),
         name="master_location-delete"),


### PR DESCRIPTION
## Summary
- add ability to view occurrence details from master location page
- implement `occurrence_details` view and URL
- add popup table template for occurrence details
- show magnifying glass icon on Occurrences tab
- include JS helper to open details window

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6877ff4063388329a5f9cdc1a12ac7aa