### PR TITLE
Handle verbatim coordinates on occurrence import

### DIFF
--- a/app/imports/importers/occurrence_importer.py
+++ b/app/imports/importers/occurrence_importer.py
@@ -43,6 +43,24 @@ class OccurrencesImporter(BaseImporter):
             getattr(row, 'verbatimLocality'),
             reference, author
         )
+        if new_source_location:
+            updated = False
+            sl_fields = {
+                'verbatim_elevation': getattr(row, 'verbatimElevation', None),
+                'verbatim_depth': getattr(row, 'verbatimDepth', None),
+                'verbatim_coordinates': getattr(row, 'verbatimCoordinates', None),
+                'verbatim_latitude': getattr(row, 'verbatimLatitude', None),
+                'verbatim_longitude': getattr(row, 'verbatimLongitude', None),
+                'verbatim_coordinate_system': getattr(row, 'verbatimCoordinateSystem', None),
+                'verbatim_srs': getattr(row, 'verbatimSRS', None),
+            }
+            for field, value in sl_fields.items():
+                cleaned_value = self.possible_nan_to_none(value)
+                if cleaned_value is not None and getattr(new_source_location, field) != cleaned_value:
+                    setattr(new_source_location, field, cleaned_value)
+                    updated = True
+            if updated:
+                new_source_location.save()
         new_event, created = Event.objects.get_or_create(
             verbatim_event_date=self.possible_nan_to_none(getattr(row, 'verbatimEventDate')),
             source_habitat=habitat

--- a/app/tests/imports/test_occurence_import.py
+++ b/app/tests/imports/test_occurence_import.py
@@ -3,7 +3,7 @@ from allauth.socialaccount.models import SocialAccount
 from django.test import Client, TestCase
 from django.contrib.messages import get_messages
 from django.contrib.auth.models import User
-from mb.models import ChoiceValue
+from mb.models import ChoiceValue, SourceLocation
 from .utils.mock_api import generate_mock_api
 
 class OccurenceImporterTest(TestCase):
@@ -27,6 +27,15 @@ class OccurenceImporterTest(TestCase):
         self.assertEqual(len(messages), 2)
         self.assertEqual(str(messages[0]), 'File imported successfully. 6 rows of data were imported. (0 rows were skipped.)')
         self.assertEqual(response.status_code, 302)
+
+    def test_coordinates_populated(self):
+        with open('tests/imports/assets/occurence/valid_occurences_file.tsv', 'r') as fp:
+            self.client.post('/import/occurrences', {'name': 'fred', 'csv_file': fp})
+
+        loc = SourceLocation.objects.get(name='Aberdare National Park, Kenya')
+        self.assertEqual(loc.verbatim_latitude, '12.3456')
+        self.assertEqual(loc.verbatim_longitude, '-78.9012')
+        self.assertEqual(loc.verbatim_coordinate_system, 'decimal degrees')
 
     def test_import_invalid_occurences(self):
         with open('tests/imports/assets/occurence/invalid_occurences_file.tsv', 'r') as fp:


### PR DESCRIPTION
## Summary
- update occurrence importer to store verbatim coordinate fields on `SourceLocation`
- add regression test ensuring coordinates are populated

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_687ffc03e22c8329ad9b9abfe89bdff6