### PR TITLE
Add status filter to SourceReference

### DIFF
--- a/app/mb/filters.py
+++ b/app/mb/filters.py
@@ -122,10 +122,11 @@ class SourceEntityFilter(django_filters.FilterSet):
 
 class SourceReferenceFilter(django_filters.FilterSet):
     citation = django_filters.CharFilter(lookup_expr='icontains', label='Reference contains')
+    status = django_filters.ChoiceFilter(choices=SourceReference.STATUS, label='Status')
 
     class Meta:
         model = SourceReference
-        fields = ['citation',]
+        fields = ['citation', 'status']
 
 class TaxonomicUnitsFilter(django_filters.FilterSet):
     tsn = django_filters.NumberFilter(label='Taxonomic Serial Number (TSN)')


### PR DESCRIPTION
## Summary
- allow filtering source references by status

## Testing
- `python manage.py test -v 2` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68813e0804a483298b547844ec216158