### PR TITLE
Add Getty TGN search API

### DIFF
--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -89,6 +89,7 @@ INSTALLED_APPS = [
     'itis',
     'exports',
     'matchtools',
+    'tgn',
 
     'allauth',
     'allauth.account',

--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -304,3 +304,36 @@ if DEBUG:
         'debug_toolbar.panels.logging.LoggingPanel',
         'debug_toolbar.panels.redirects.RedirectsPanel',
     ]
+
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+
+    'formatters': {
+        'verbose': {
+            'format': '[{asctime}] {levelname} {name}: {message}',
+            'style': '{',
+        },
+    },
+
+    'handlers': {
+        'console': {
+            'class': 'logging.StreamHandler',
+            'level': 'DEBUG',
+            'formatter': 'verbose',
+        },
+    },
+
+    'loggers': {
+        'tgn': {  # specific app/module logger
+            'handlers': ['console'],
+            'level': 'DEBUG',
+            'propagate': False,
+        },
+        'django': {
+            'handlers': ['console'],
+            'level': 'WARNING',
+            'propagate': True,
+        },
+    },
+}

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -26,7 +26,7 @@ urllib3==2.5.0
 requests-mock==1.11.0
 fuzzywuzzy==0.18.0
 python-Levenshtein==0.25.0
-
+beautifulsoup4>=4.11.1
 #OLD
 #Django==3.1.14
 #django-allauth==0.44.0

--- a/app/tgn/__init__.py
+++ b/app/tgn/__init__.py
@@ -1,0 +1,1 @@
+"""TGN app initialization."""

--- a/app/tgn/admin.py
+++ b/app/tgn/admin.py
@@ -1,0 +1,3 @@
+from django.contrib import admin
+
+# Register your models here.

--- a/app/tgn/apps.py
+++ b/app/tgn/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class TgnConfig(AppConfig):
+    default_auto_field = 'django.db.models.BigAutoField'
+    name = 'tgn'

--- a/app/tgn/models.py
+++ b/app/tgn/models.py
@@ -1,0 +1,3 @@
+from django.db import models
+
+# Create your models here if needed.

--- a/app/tgn/services.py
+++ b/app/tgn/services.py
@@ -1,9 +1,15 @@
+import logging
+from typing import List, Dict
+
 import requests
 
 BASE_TGN_URL = "https://vocab.getty.edu/sparql.json"
 
 
-def search_tgn(name: str, place_type: str = None):
+LOG = logging.getLogger(__name__)
+
+
+def search_tgn(name: str, place_type: str = None) -> List[Dict[str, str]]:
     """Query Getty TGN via SPARQL by place name and optional place type."""
     query = f"""
     SELECT ?place ?placeLabel ?coords ?placetypeLabel ?countryLabel ?continentLabel
@@ -29,9 +35,13 @@ def search_tgn(name: str, place_type: str = None):
             """,
         )
 
-    response = requests.get(BASE_TGN_URL, params={"query": query})
-    response.raise_for_status()
-    data = response.json()
+    try:
+        response = requests.get(BASE_TGN_URL, params={"query": query}, timeout=10)
+        response.raise_for_status()
+        data = response.json()
+    except (requests.RequestException, ValueError) as exc:
+        LOG.warning("TGN request failed: %s", exc)
+        raise RuntimeError("Failed to query Getty TGN") from exc
 
     results = []
     for b in data.get("results", {}).get("bindings", []):

--- a/app/tgn/services.py
+++ b/app/tgn/services.py
@@ -1,56 +1,125 @@
 import logging
-from typing import List, Dict
-
 import requests
+from bs4 import BeautifulSoup
+from urllib.parse import urljoin
+import re
 
-BASE_TGN_URL = "https://vocab.getty.edu/sparql.json"
+logger = logging.getLogger(__name__)
 
 
-LOG = logging.getLogger(__name__)
+def search_tgn(name):
+    logger.debug(f"Starting TGN search for name: {name}")
 
-
-def search_tgn(name: str, place_type: str = None) -> List[Dict[str, str]]:
-    """Query Getty TGN via SPARQL by place name and optional place type."""
-    query = f"""
-    SELECT ?place ?placeLabel ?coords ?placetypeLabel ?countryLabel ?continentLabel
-    WHERE {{
-      ?place rdfs:label ?placeLabel .
-      FILTER(CONTAINS(LCASE(?placeLabel), LCASE(\"{name}\"))) .
-      OPTIONAL {{ ?place gvp:placeTypePreferred ?placetype . ?placetype rdfs:label ?placetypeLabel. }}
-      OPTIONAL {{ ?place gvp:broaderPreferred* ?country . ?country gvp:placeTypePreferred gvp:country . ?country rdfs:label ?countryLabel. }}
-      OPTIONAL {{ ?place gvp:broaderPreferred* ?continent . ?continent gvp:placeTypePreferred gvp:continent . ?continent rdfs:label ?continentLabel. }}
-      OPTIONAL {{ ?place wgs:lat ?lat ; wgs:long ?lon . BIND(CONCAT(STR(?lat), ",", STR(?lon)) AS ?coords) }}
-    }}
-    LIMIT 20
-    """
-
-    if place_type:
-        query = query.replace(
-            "WHERE {",
-            f"""
-            WHERE {{
-              ?place gvp:placeTypePreferred ?ptype .
-              ?ptype rdfs:label ?ptypeLabel .
-              FILTER(CONTAINS(LCASE(?ptypeLabel), LCASE(\"{place_type}\"))) .
-            """,
-        )
+    base_url = "https://www.getty.edu/vow/TGNServlet"
+    search_params = {
+        "find": name,
+        "place": "",
+        "nation": "",
+        "english": "Y",
+        "page": "1",
+    }
 
     try:
-        response = requests.get(BASE_TGN_URL, params={"query": query}, timeout=10)
-        response.raise_for_status()
-        data = response.json()
-    except (requests.RequestException, ValueError) as exc:
-        LOG.warning("TGN request failed: %s", exc)
-        raise RuntimeError("Failed to query Getty TGN") from exc
+        search_response = requests.get(base_url, params=search_params, timeout=10)
+        logger.debug(f"Constructed search URL: {search_response.url}")
+        logger.debug(f"Search page HTML (first 500 chars): {search_response.text[:500]}")
+        search_response.raise_for_status()
+    except requests.RequestException as e:
+        logger.warning(f"TGN search request failed: {e}")
+        return []
+
+    soup = BeautifulSoup(search_response.text, 'html.parser')
+    links = soup.select("a[href*='TGNFullDisplay?']")
+    logger.debug(f"Found {len(links)} TGN display links.")
 
     results = []
-    for b in data.get("results", {}).get("bindings", []):
-        results.append({
-            "uri": b.get("place", {}).get("value"),
-            "name": b.get("placeLabel", {}).get("value"),
-            "coordinates": b.get("coords", {}).get("value") if "coords" in b else None,
-            "place_type": b.get("placetypeLabel", {}).get("value") if "placetypeLabel" in b else None,
-            "country": b.get("countryLabel", {}).get("value") if "countryLabel" in b else None,
-            "continent": b.get("continentLabel", {}).get("value") if "continentLabel" in b else None,
-        })
+
+    for link in links:
+        href = link.get("href")
+        full_url = urljoin("https://www.getty.edu/vow/", href)
+        logger.debug(f"Fetching display page: {full_url}")
+
+        try:
+            detail_response = requests.get(full_url, timeout=10)
+            detail_response.raise_for_status()
+        except requests.RequestException as e:
+            logger.warning(f"Failed to fetch {full_url}: {e}")
+            continue
+
+        detail_soup = BeautifulSoup(detail_response.text, 'html.parser')
+
+        tgn_id = href.split("subjectid=")[-1] if "subjectid=" in href else "NA"
+
+        # Preferred name extraction
+        preferred_name_tag = detail_soup.find("a", onmouseover=lambda x: x and "Preferred Name" in x)
+        preferred_name = "NA"
+        if preferred_name_tag:
+            bold_parent = preferred_name_tag.find_parent("nobr")
+            if bold_parent:
+                bold_text = bold_parent.find("b")
+                if bold_text:
+                    preferred_name = bold_text.get_text(strip=True)
+
+        # Place type extraction
+        place_type = "NA"
+        for td in detail_soup.select("td[colspan='4'][valign='BOTTOM'] span.page b"):
+            text = td.get_text(strip=True)
+            if '(' in text and ')' in text:
+                place_type = text.split('(')[-1].rstrip(')')
+                break
+
+        # Coordinates (decimal degrees)
+        latitude = "NA"
+        longitude = "NA"
+        for span in detail_soup.find_all("span", class_="page"):
+            full_text = span.get_text(separator=" ", strip=True).replace("\xa0", " ")
+            logger.debug(f"Coordinate candidate text: {full_text}")
+            if "Lat:" in full_text and "decimal degrees" in full_text:
+                try:
+                    latitude = full_text.split("Lat:")[1].split("decimal degrees")[0].strip()
+                except Exception as e:
+                    logger.warning(f"Error parsing latitude: {e}")
+            if "Long:" in full_text and "decimal degrees" in full_text:
+                try:
+                    longitude = full_text.split("Long:")[1].split("decimal degrees")[0].strip()
+                except Exception as e:
+                    logger.warning(f"Error parsing longitude: {e}")
+
+        # Hierarchy extraction
+        hierarchy = {
+            "Continent": "",
+            "Country": "",
+            "State or Province": "NA",
+            "County": "NA",
+            "Municipality": "NA"
+        }
+        table_tags = detail_soup.select("td span.page")
+        for tag in table_tags:
+            txt = tag.get_text()
+            if "(continent)" in txt:
+                hierarchy["Continent"] = txt.split("(")[0].strip()
+            elif "(nation)" in txt:
+                hierarchy["Country"] = txt.split("(")[0].strip()
+            elif "(state)" in txt:
+                hierarchy["State or Province"] = txt.split("(")[0].strip()
+            elif "(province)" in txt:
+                hierarchy["State or Province"] = txt.split("(")[0].strip()
+            elif "(county)" in txt:
+                hierarchy["County"] = txt.split("(")[0].strip()
+            elif "(municipality)" in txt:
+                hierarchy["Municipality"] = txt.split("(")[0].strip()
+
+        result = {
+            "tgn_id": tgn_id,
+            "preferred_name": preferred_name,
+            "place_type": place_type,
+            "latitude": latitude,
+            "longitude": longitude,
+            **hierarchy
+        }
+
+        logger.debug(f"Parsed TGN display result: {result}")
+        results.append(result)
+
+    logger.info(f"TGN search completed: {len(results)} result(s) found for '{name}'")
     return results

--- a/app/tgn/services.py
+++ b/app/tgn/services.py
@@ -1,0 +1,46 @@
+import requests
+
+BASE_TGN_URL = "https://vocab.getty.edu/sparql.json"
+
+
+def search_tgn(name: str, place_type: str = None):
+    """Query Getty TGN via SPARQL by place name and optional place type."""
+    query = f"""
+    SELECT ?place ?placeLabel ?coords ?placetypeLabel ?countryLabel ?continentLabel
+    WHERE {{
+      ?place rdfs:label ?placeLabel .
+      FILTER(CONTAINS(LCASE(?placeLabel), LCASE(\"{name}\"))) .
+      OPTIONAL {{ ?place gvp:placeTypePreferred ?placetype . ?placetype rdfs:label ?placetypeLabel. }}
+      OPTIONAL {{ ?place gvp:broaderPreferred* ?country . ?country gvp:placeTypePreferred gvp:country . ?country rdfs:label ?countryLabel. }}
+      OPTIONAL {{ ?place gvp:broaderPreferred* ?continent . ?continent gvp:placeTypePreferred gvp:continent . ?continent rdfs:label ?continentLabel. }}
+      OPTIONAL {{ ?place wgs:lat ?lat ; wgs:long ?lon . BIND(CONCAT(STR(?lat), ",", STR(?lon)) AS ?coords) }}
+    }}
+    LIMIT 20
+    """
+
+    if place_type:
+        query = query.replace(
+            "WHERE {",
+            f"""
+            WHERE {{
+              ?place gvp:placeTypePreferred ?ptype .
+              ?ptype rdfs:label ?ptypeLabel .
+              FILTER(CONTAINS(LCASE(?ptypeLabel), LCASE(\"{place_type}\"))) .
+            """,
+        )
+
+    response = requests.get(BASE_TGN_URL, params={"query": query})
+    response.raise_for_status()
+    data = response.json()
+
+    results = []
+    for b in data.get("results", {}).get("bindings", []):
+        results.append({
+            "uri": b.get("place", {}).get("value"),
+            "name": b.get("placeLabel", {}).get("value"),
+            "coordinates": b.get("coords", {}).get("value") if "coords" in b else None,
+            "place_type": b.get("placetypeLabel", {}).get("value") if "placetypeLabel" in b else None,
+            "country": b.get("countryLabel", {}).get("value") if "countryLabel" in b else None,
+            "continent": b.get("continentLabel", {}).get("value") if "continentLabel" in b else None,
+        })
+    return results

--- a/app/tgn/tests.py
+++ b/app/tgn/tests.py
@@ -1,0 +1,3 @@
+from django.test import TestCase
+
+# Create your tests here.

--- a/app/tgn/tests.py
+++ b/app/tgn/tests.py
@@ -1,3 +1,16 @@
+from django.urls import reverse
 from django.test import TestCase
+import requests_mock
 
-# Create your tests here.
+from .services import BASE_TGN_URL
+
+
+class TgnSearchTests(TestCase):
+    @requests_mock.Mocker()
+    def test_search_place_handles_network_error(self, mocker):
+        mocker.get(BASE_TGN_URL, status_code=403, text='Forbidden')
+        url = reverse('tgn_search')
+        response = self.client.get(url, {'name': 'Amboseli'})
+        self.assertEqual(response.status_code, 502)
+        self.assertIn('Failed to query Getty TGN', response.json()['error'])
+

--- a/app/tgn/urls.py
+++ b/app/tgn/urls.py
@@ -1,0 +1,6 @@
+from django.urls import path
+from . import views
+
+urlpatterns = [
+    path('search/', views.search_place, name='tgn_search'),
+]

--- a/app/tgn/views.py
+++ b/app/tgn/views.py
@@ -16,6 +16,10 @@ def search_place(request):
     if cached:
         return JsonResponse({"results": cached})
 
-    results = search_tgn(name, place_type if place_type else None)
+    try:
+        results = search_tgn(name, place_type if place_type else None)
+    except RuntimeError as exc:
+        return JsonResponse({"error": str(exc)}, status=502)
+
     cache.set(cache_key, results, timeout=86400)
     return JsonResponse({"results": results})

--- a/app/tgn/views.py
+++ b/app/tgn/views.py
@@ -1,0 +1,21 @@
+from django.http import JsonResponse
+from django.core.cache import cache
+
+from .services import search_tgn
+
+
+def search_place(request):
+    name = request.GET.get("name", "")
+    place_type = request.GET.get("place_type", "")
+
+    if not name:
+        return JsonResponse({"error": "Missing 'name' parameter"}, status=400)
+
+    cache_key = f"tgn_{name}_{place_type}"
+    cached = cache.get(cache_key)
+    if cached:
+        return JsonResponse({"results": cached})
+
+    results = search_tgn(name, place_type if place_type else None)
+    cache.set(cache_key, results, timeout=86400)
+    return JsonResponse({"results": results})

--- a/app/tgn/views.py
+++ b/app/tgn/views.py
@@ -17,7 +17,8 @@ def search_place(request):
         return JsonResponse({"results": cached})
 
     try:
-        results = search_tgn(name, place_type if place_type else None)
+#        results = search_tgn(name, place_type if place_type else None)
+        results = search_tgn(name)
     except RuntimeError as exc:
         return JsonResponse({"error": str(exc)}, status=502)
 

--- a/app/urls/__init__.py
+++ b/app/urls/__init__.py
@@ -31,7 +31,8 @@ urlpatterns = [
     path('import/', include('urls.imports')),
     path('exports/', include('urls.exports')),
     path('matchtools/', include('urls.matchtools')),
-    
+    path('tgn/', include('tgn.urls')),
+
     path('admin/', admin.site.urls),
     path('select2/', include('django_select2.urls')),
     path('accounts/', include('allauth.urls')),


### PR DESCRIPTION
## Summary
- create new Django app `tgn`
- add a simple search service to query Getty TGN
- expose `/tgn/search/` endpoint with optional caching
- register new URLs and add app to settings

## Testing
- `pip install Django requests` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688290ba93788329b4a23b4462697d82