### PR TITLE
Add occurrence list to master location page

### DIFF
--- a/app/mb/templates/export/export_ets.html
+++ b/app/mb/templates/export/export_ets.html
@@ -24,7 +24,7 @@
 
     <p>MammalBase uses the <b>Ecological Traitdata Standard (ETS)</b> format for the export.</p>
     <p>The ETS format allows for the integration of the dataset into your research workflow.<br>
-      To learn more about the ETS terminology, please see: <a href="https://terminologies.gfbio.org/terms/ets/pages/" target="_blank">Ecological Trait-data Standard Vocabulary</a>
+      To learn more about the ETS terminology, please see: <a href="https://terminologies.gfbio.org/terms/ets/pages/" target="_blank">Ecological Trait-data Standard Vocabulary <span class="fa fa-external-link"></span></a>
     </p>
     <p>Please fill in your email address. The exported files will be zipped and a download link will be sent to the given email.</p>
 

--- a/app/mb/templates/matchtool/location_match_detail.html
+++ b/app/mb/templates/matchtool/location_match_detail.html
@@ -73,7 +73,7 @@
               <td style="text-align:center">-</td>
             {% endif %}
             {% if location.geonameId %}
-              <td><a href="https://www.geonames.org/{{ location.geonameId }}" target="_blank" rel="noopener noreferrer">{{ location.geonameId }}</a></td>
+              <td><a href="https://www.geonames.org/{{ location.geonameId }}" target="_blank" rel="noopener noreferrer">{{ location.geonameId }} <span class="fa fa-external-link"></span></a></td>
             {% else %}
               <td style="text-align:center">-</td>
             {% endif %}

--- a/app/mb/templates/mb/master_location_detail.html
+++ b/app/mb/templates/mb/master_location_detail.html
@@ -12,6 +12,7 @@
 <div class="w3-bar w3-border-bottom" style="margin-bottom:16px;">
   <button class="w3-bar-item w3-button tablink {% if not show_source_tab %}w3-teal{% endif %}" onclick="openTab(event,'MasterTab')">Master</button>
   <button class="w3-bar-item w3-button tablink {% if show_source_tab %}w3-teal{% endif %}" onclick="openTab(event,'SourceTab')">Source</button>
+  <button class="w3-bar-item w3-button tablink" onclick="openTab(event,'OccurrenceTab')">Occurrences</button>
 </div>
 
 <div id="MasterTab" class="tab" style="display:{% if not show_source_tab %}block{% else %}none{% endif %}">
@@ -60,10 +61,16 @@
         <th class="w3-quarter">Location According to</th>
         <td class="w3-threequarter">{{ master_location.location_according_to }}</td>
       </tr>
+      {% location_id_url master_location as loc_url %}
       <tr>
         <th class="w3-quarter">Location ID</th>
-        <td class="w3-threequarter"><a title="Press for Details" target="_blank"
-          href="https://geonames.org/{{ master_location.location_id }}">{{ master_location.location_id }}<span class="fa fa-link w3-small"></span></a></td>
+        <td class="w3-threequarter">
+          {% if loc_url %}
+            <a title="Press for Details" target="_blank" href="{{ loc_url }}">{{ master_location.location_id }} <span class="fa fa-external-link w3-small"></span></a>
+          {% else %}
+            {{ master_location.location_id }}
+          {% endif %}
+        </td>
       </tr>
       <tr>
         <th class="w3-quarter">Location Remarks</th>
@@ -116,6 +123,37 @@
   </table>
   {% else %}
     <p>There are no matched source locations.</p>
+  {% endif %}
+</section>
+</div>
+
+<div id="OccurrenceTab" class="tab" style="display:none;">
+<section class="w3-threequarter w3-container">
+  <header class="w3-container w3-text-teal">
+    <h2>Occurrences</h2>
+  </header>
+
+  {% if occurrences %}
+  <table class="mb-list w3-table-all w3-small w3-responsive">
+    <thead>
+      <tr>
+        <th>Taxon</th>
+        <th>Rank</th>
+        <th>Higher Classification</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for me in occurrences %}
+      <tr>
+        <td class="mb-public-internal"><a title="Press for Details" href="{% url 'master_entity-detail' pk=me.pk %}">{{ me.name }} <span class="fa fa-link w3-small"></span></a></td>
+        <td>{{ me.entity }}</td>
+        <td>{{ me.taxon.higher_classification }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% else %}
+    <p>There are no occurrences.</p>
   {% endif %}
 </section>
 </div>

--- a/app/mb/templates/mb/source_reference_detail.html
+++ b/app/mb/templates/mb/source_reference_detail.html
@@ -33,8 +33,7 @@
     <tr>
       <th class="w3-quarter">DOI:</th>
       {% if source_reference.doi %}
-        <td class="mb-private-internal w3-threequarter"><a title="Press for Details" href="http://dx.doi.org/{{ source_reference.doi }}" target="_blank">
-          {{ source_reference.doi }} <span class="fa fa-external-link"></span></a></td>
+        <td class="mb-private-internal w3-threequarter"><a title="Press for Details" href="http://dx.doi.org/{{ source_reference.doi }}" target="_blank">{{ source_reference.doi }} <span class="fa fa-external-link"></span></a></td>
       {% else %}
         <td class="w3-threequarter"></td>
       {% endif %}

--- a/app/mb/templatetags/custom_tags.py
+++ b/app/mb/templatetags/custom_tags.py
@@ -42,3 +42,21 @@ def trim_gender(value):
 @register.filter(name="trim_lifestage")
 def trim_lifestage(value):
     return value.replace("LifeStage -", "")
+
+
+@register.simple_tag
+def location_id_url(location):
+    """Return external URL for a master location ID based on provider."""
+    if not location or not location.location_id:
+        return ""
+
+    provider = (location.location_according_to or "").lower()
+    if provider.startswith("geonames"):
+        return f"https://www.geonames.org/{location.location_id}"
+    if provider.startswith("tgn"):
+        return f"http://vocab.getty.edu/tgn/{location.location_id}"
+
+    if location.location_id.startswith("http"):
+        return location.location_id
+
+    return location.location_id

--- a/app/mb/views/unsorted.py
+++ b/app/mb/views/unsorted.py
@@ -2162,6 +2162,18 @@ def master_location_detail(request, pk):
 
     show_source_tab = bool(request.GET)
 
+    occurrences = MasterEntity.objects.is_active().filter(
+        entityrelation__is_active=True,
+        entityrelation__source_entity__is_active=True,
+        entityrelation__source_entity__taxon_occurrence__is_active=True,
+        entityrelation__source_entity__taxon_occurrence__source_location__is_active=True,
+        entityrelation__source_entity__taxon_occurrence__source_location__locationrelation__is_active=True,
+        entityrelation__source_entity__taxon_occurrence__source_location__locationrelation__master_location=master_location,
+        entityrelation__source_entity__taxon_occurrence__source_reference__is_active=True,
+        entityrelation__source_entity__taxon_occurrence__source_reference__referencerelation__is_active=True,
+        entityrelation__source_entity__taxon_occurrence__source_reference__referencerelation__master_reference__is_active=True,
+    ).select_related('entity', 'taxon').order_by('name').distinct()
+
     return render(
         request,
         'mb/master_location_detail.html',
@@ -2170,6 +2182,7 @@ def master_location_detail(request, pk):
             'filter': filter,
             'page_obj': page_obj,
             'show_source_tab': show_source_tab,
+            'occurrences': occurrences,
         },
     )
 


### PR DESCRIPTION
## Summary
- show occurrences for each master location
- query master entities with active relations
- display occurrences on a new tab
- fix query to use correct relation name
- ensure external links use the right icon
- handle Location ID URLs via `location_according_to`

## Testing
- `python app/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686199907d948329b09a9826d55372af