### PR TITLE
Potential fix for code scanning alert no. 5: Clear-text logging of sensitive information

### DIFF
--- a/app/tgn/services.py
+++ b/app/tgn/services.py
@@ -136,7 +136,7 @@ def search_tgn(name, nature_reserve=False):
             **hierarchy
         }
 
-        logger.debug(f"Parsed TGN display result: {result}")
+        logger.debug(f"Parsed TGN display result for ID: {tgn_id}")
         results.append(result)
 
     logger.info(f"TGN search completed: {len(results)} result(s) found for '{name}'")


### PR DESCRIPTION
Potential fix for [https://github.com/karilint/mammalbase/security/code-scanning/5](https://github.com/karilint/mammalbase/security/code-scanning/5)

In general, to fix clear-text logging of sensitive information, you should avoid logging full objects that contain sensitive fields; instead, either (a) remove sensitive fields from the logged data, (b) mask/redact them, or (c) log only high-level, non-sensitive metadata (such as counts, IDs, or status). The goal is to preserve observability without storing personal or sensitive content in logs.

For this specific case, the problematic statement is `logger.debug(f"Parsed TGN display result: {result}")` on line 139, where `result` contains potentially sensitive fields (coordinates and hierarchy). The simplest, least-invasive fix is to stop logging the full `result` dictionary. We can still keep useful debug information by logging only the non-sensitive identifier `tgn_id` (and possibly `place_type`), or even just confirm that a result was parsed. This change preserves existing behavior of the function (returned data is unchanged, network behavior is unchanged) while eliminating sensitive content from logs.

Concretely, in `app/tgn/services.py`, replace line 139 with a log that excludes sensitive fields, e.g. `logger.debug(f"Parsed TGN display result for ID: {tgn_id}")`. No new imports or helper methods are required; we only modify this one logging call. This single change addresses all alert variants because they all originate from logging the `result` object that contains the tainted data (including values sourced from lines 90, 91, 97, and 102).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
