### PR TITLE
Potential fix for code scanning alert no. 6: Information exposure through an exception

### DIFF
--- a/app/wdpa/views.py
+++ b/app/wdpa/views.py
@@ -3,6 +3,10 @@ from django.core.cache import cache
 
 from .services import search_wdpa
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 
 def search_place(request):
     name = request.GET.get("name", "")
@@ -17,7 +21,8 @@ def search_place(request):
     try:
         results = search_wdpa(name)
     except RuntimeError as exc:
-        return JsonResponse({"error": str(exc)}, status=502)
+        logger.exception("WDPA search failed for name %r", name)
+        return JsonResponse({"error": "Failed to fetch WDPA data"}, status=502)
 
     cache.set(cache_key, results, timeout=86400)
     return JsonResponse({"results": results})


### PR DESCRIPTION
Potential fix for [https://github.com/karilint/mammalbase/security/code-scanning/6](https://github.com/karilint/mammalbase/security/code-scanning/6)

In general, to fix this kind of problem you should avoid returning raw exception messages to clients. Instead, log the details on the server (so developers can debug) and send the client a generic, non‑sensitive error message. This breaks the information flow from internal exception content to the HTTP response while preserving observability on the backend.

For this specific view in `app/wdpa/views.py`, the best fix is:

- Keep catching `RuntimeError` so the view can still handle backend/search failures.
- Inside the `except` block, log the exception (including stack trace) using Django’s standard logging facilities, which are already well‑integrated with the project, rather than returning it to the client.
- Replace `{"error": str(exc)}` with a generic message such as `{"error": "Upstream search service failed"}` or simply `{"error": "An internal error occurred"}`. This maintains the error contract (a JSON object with an `"error"` key and a 502 status) while avoiding leakage.
- To log the exception, import Python’s `logging` module at the top of the file and create a module‑level logger with `logging.getLogger(__name__)`, then call `logger.exception(...)` in the `except` block. `logger.exception` automatically includes the stack trace.

Concretely:

- At the top of `app/wdpa/views.py`, add `import logging` and define `logger = logging.getLogger(__name__)`.
- In `search_place`, change the `except RuntimeError as exc:` block to call `logger.exception("WDPA search failed for name %r", name)` and return a generic error response rather than `str(exc)`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
