### PR TITLE
Expand Protected Planet name parsing

### DIFF
--- a/app/wdpa/services.py
+++ b/app/wdpa/services.py
@@ -60,9 +60,14 @@ def search_wdpa(name):
         attr_info = _find_attr_json(detail_soup, ":attributes-info")
         original_name = "NA"
         if attr_info:
+            name_candidates = {}
             for item in attr_info[0].get("attributes", []):
-                if item.get("title") == "Original Name":
-                    original_name = item.get("value", "NA")
+                title = item.get("title")
+                if title in {"Original Name", "Name", "English Name"}:
+                    name_candidates[title] = item.get("value", "NA")
+            for title in ("Original Name", "Name", "English Name"):
+                if name_candidates.get(title):
+                    original_name = name_candidates[title]
                     break
         results.append({
             "wdpa_id": wdpa_id,


### PR DESCRIPTION
### Motivation
- Ensure the WDPA detail parser selects a readable name value by falling back to `Name` and `English Name` when `Original Name` is not present.

### Description
- Update `app/wdpa/services.py` to collect attributes titled `Original Name`, `Name`, and `English Name` and pick the first available in the order `("Original Name", "Name", "English Name")`, defaulting to `"NA"`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696dfb2f87dc8329a47716961088a55c)